### PR TITLE
Upgrade Cake to 0.17.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,7 @@
+version: 1.0.{build}
+os: Visual Studio 2015
+# Build script
+build_script:
+  - ps: .\build.ps1 build.cake -Target AppVeyor
+# Tests
+test: off

--- a/src/Cake.HipChat/Cake.HipChat.csproj
+++ b/src/Cake.HipChat/Cake.HipChat.csproj
@@ -34,12 +34,12 @@
     <DocumentationFile>bin\Release\Cake.HipChat.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Common, Version=0.15.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Common.0.15.2\lib\net45\Cake.Common.dll</HintPath>
+    <Reference Include="Cake.Common, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Common.0.17.0\lib\net45\Cake.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Cake.Core, Version=0.15.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.15.2\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="HipChat.Net, Version=1.3.1.0, Culture=neutral, PublicKeyToken=85d27803db462816, processorArchitecture=MSIL">

--- a/src/Cake.HipChat/packages.config
+++ b/src/Cake.HipChat/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Common" version="0.15.2" targetFramework="net452" />
-  <package id="Cake.Core" version="0.15.2" targetFramework="net452" />
+  <package id="Cake.Common" version="0.17.0" targetFramework="net452" />
+  <package id="Cake.Core" version="0.17.0" targetFramework="net452" />
   <package id="HipChat.Net" version="1.3.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Cake 0.18.0 will requires at least version 0.16.x to work.